### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,9 @@ on:
         description: 'Release tag to publish (e.g. v1.0.1)'
         required: false
 
+permissions:
+  contents: read
+
 env:
   ISO_NAME: arklinux
   ARCH: x86_64


### PR DESCRIPTION
Potential fix for [https://github.com/Superman08091992/ARKlinux/security/code-scanning/2](https://github.com/Superman08091992/ARKlinux/security/code-scanning/2)

To fix the problem, define explicit least‑privilege permissions for the workflow so that the GITHUB_TOKEN does not fall back to broad repository defaults. The cleanest approach here is to set a restrictive `permissions:` block at the workflow root, which then applies to all jobs (including `build`) that do not override it. This both documents the intended access and ensures consistent behavior if the workflow is copied elsewhere.

The single best minimal fix without changing functionality is:

- Add a root‑level `permissions:` block after the `on:` section and before `env:`.  
- Use `contents: read` as the primary setting, which is sufficient for `actions/checkout` and does not grant write access to repository contents. The artifact actions do not require additional repository‑scoped permissions.

Concretely, in `.github/workflows/build-release.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block (lines 3–16) and the `env:` block (line 17). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
