### PR TITLE
Add portable operational skills for ARKlinux evidence gates

### DIFF
--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -1,0 +1,27 @@
+name: Agent Skills validation
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/validate-agent-skills.py'
+      - '.github/workflows/agent-skills.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+      - 'scripts/validate-agent-skills.py'
+      - '.github/workflows/agent-skills.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Validate Agent Skills
+        run: python3 scripts/validate-agent-skills.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# ARKlinux agent instructions
+
+## Authority and truth boundary
+
+- Treat the repository, current commit, executed commands, logs, and retained artifacts as the evidence base.
+- Do not claim a capability was implemented, executed, or verified unless the current commit has direct evidence.
+- Do not broaden a milestone beyond its stated acceptance criteria.
+- Do not perform physical-disk writes, hardware installation, release publication, PR merge, artifact deletion, or real external execution without explicit authorization.
+- Stop at the first failing command, preserve the relevant evidence, and identify the exact blocker.
+
+## Operational skills
+
+For recurring tasks, consult the matching skill before acting:
+
+- ISO construction and QEMU live boot: `skills/arklinux-iso-build-proof/SKILL.md`
+- PR and evidence review: `skills/arklinux-pr-evidence-review/SKILL.md`
+- Permanent ISO release and custody: `skills/arklinux-release-custody/SKILL.md`
+- Disposable QEMU installation and installed reboot: `skills/arklinux-qemu-install-proof/SKILL.md`
+
+When more than one skill appears relevant, apply the narrowest skill first and keep each resulting pull request within one milestone boundary.

--- a/scripts/validate-agent-skills.py
+++ b/scripts/validate-agent-skills.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Validate the repository's portable Agent Skills without external packages."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = ROOT / "skills"
+
+
+def parse_frontmatter(path: Path) -> tuple[dict[str, str], str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError("SKILL.md must begin with YAML frontmatter")
+
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise ValueError("SKILL.md frontmatter is not closed") from exc
+
+    fields: dict[str, str] = {}
+    for line in lines[1:end]:
+        if not line or line.startswith((" ", "\t", "#")):
+            continue
+        if ":" not in line:
+            raise ValueError(f"invalid top-level frontmatter line: {line!r}")
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"').strip("'")
+
+    body = "\n".join(lines[end + 1 :]).strip()
+    return fields, body
+
+
+def validate_skill(path: Path) -> list[str]:
+    errors: list[str] = []
+    parent_name = path.parent.name
+
+    try:
+        fields, body = parse_frontmatter(path)
+    except (OSError, UnicodeError, ValueError) as exc:
+        return [str(exc)]
+
+    name = fields.get("name", "")
+    description = fields.get("description", "")
+
+    if not name:
+        errors.append("missing required frontmatter field: name")
+    elif len(name) > 64:
+        errors.append("name exceeds 64 characters")
+    elif not NAME_RE.fullmatch(name):
+        errors.append("name must contain only lowercase letters, digits, and single hyphens")
+    elif name != parent_name:
+        errors.append(f"name {name!r} must match parent directory {parent_name!r}")
+
+    if not description:
+        errors.append("missing required frontmatter field: description")
+    elif len(description) > 1024:
+        errors.append("description exceeds 1024 characters")
+
+    if not body:
+        errors.append("instruction body is empty")
+
+    if len(path.read_text(encoding="utf-8").splitlines()) > 500:
+        errors.append("SKILL.md exceeds the recommended 500-line limit")
+
+    return errors
+
+
+def main() -> int:
+    if not SKILLS_ROOT.is_dir():
+        print(f"ERROR: skills directory not found: {SKILLS_ROOT}", file=sys.stderr)
+        return 1
+
+    skill_files = sorted(SKILLS_ROOT.glob("*/SKILL.md"))
+    if not skill_files:
+        print("ERROR: no skills/*/SKILL.md files found", file=sys.stderr)
+        return 1
+
+    skill_dirs = sorted(path for path in SKILLS_ROOT.iterdir() if path.is_dir())
+    missing = [path for path in skill_dirs if not (path / "SKILL.md").is_file()]
+
+    failures = 0
+    for directory in missing:
+        failures += 1
+        print(f"FAIL {directory.relative_to(ROOT)}: missing SKILL.md")
+
+    names: set[str] = set()
+    for skill_file in skill_files:
+        errors = validate_skill(skill_file)
+        try:
+            fields, _ = parse_frontmatter(skill_file)
+            name = fields.get("name", "")
+        except ValueError:
+            name = ""
+
+        if name and name in names:
+            errors.append(f"duplicate skill name: {name}")
+        elif name:
+            names.add(name)
+
+        relative = skill_file.relative_to(ROOT)
+        if errors:
+            failures += 1
+            print(f"FAIL {relative}")
+            for error in errors:
+                print(f"  - {error}")
+        else:
+            print(f"PASS {relative}")
+
+    if failures:
+        print(f"Skill validation failed: {failures} item(s)", file=sys.stderr)
+        return 1
+
+    print(f"Skill validation passed: {len(skill_files)} skill(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,30 @@
+# ARKlinux operational skills
+
+This directory contains portable Agent Skills for recurring ARKlinux engineering and evidence tasks. Each skill is intentionally narrow. Combine skills only when the requested work actually spans more than one gate.
+
+## Current skills
+
+- `arklinux-iso-build-proof`: Build an ARKlinux ISO and prove read-only QEMU live boot.
+- `arklinux-pr-evidence-review`: Review a pull request, CI run, and artifacts against a bounded milestone claim.
+- `arklinux-release-custody`: Preserve a verified ISO as a release asset and maintain independent custody records.
+- `arklinux-qemu-install-proof`: Install only to an explicitly identified disposable QEMU disk and prove installed reboot.
+
+## Use principles
+
+1. Evidence precedes completion claims.
+2. A successful earlier run does not prove the current commit.
+3. Route, service, or file presence does not prove functional implementation.
+4. A checksum verifies bytes that exist; it cannot reconstruct a missing artifact.
+5. Never infer permission for destructive actions.
+6. Never merge, publish, delete, install to hardware, or enable real execution without explicit authorization.
+7. Keep each pull request within one milestone boundary.
+
+## Structure
+
+Every skill directory contains a standards-compatible `SKILL.md` with YAML frontmatter and Markdown instructions. Supporting scripts or references may be added when they make the workflow more deterministic.
+
+Validate the library with:
+
+```bash
+python3 scripts/validate-agent-skills.py
+```

--- a/skills/arklinux-iso-build-proof/SKILL.md
+++ b/skills/arklinux-iso-build-proof/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: arklinux-iso-build-proof
+description: Build an ARKlinux ISO from a specific repository ref, verify source and ISO checksums, boot the ISO read-only under QEMU, and produce a bounded evidence record. Use for ISO baseline builds, QEMU live-boot proof, reproducibility checks, or rerunning Milestone 1.
+compatibility: Requires git, bash, Docker or an approved Arch build environment, sha256sum, QEMU x86_64, Python 3, and write access only to repository build output.
+metadata:
+  author: 1TRUE-INC
+  version: "1.0.0"
+---
+
+# ARKlinux ISO build proof
+
+## Purpose
+
+Produce an actual ISO and evidence proving that the exact tested commit built successfully and reached the defined live-boot marker under QEMU. Do not extend the claim to installation, installed reboot, runtime integration, service completeness, or hardware readiness.
+
+## Required inputs
+
+Obtain or resolve:
+
+- repository and exact commit or branch;
+- expected ISO version and filename;
+- approved build environment;
+- output directory;
+- live-boot success marker and timeout;
+- evidence destination.
+
+If the ref, output boundary, or success marker is ambiguous, stop and resolve it before building.
+
+## Safety boundary
+
+- Write only inside the repository build directory and disposable QEMU state.
+- Do not inspect, infer, mount, partition, format, or write a physical block device.
+- Boot the ISO read-only and do not invoke the installer.
+- Do not use an earlier artifact as proof for a newer commit.
+
+## Workflow
+
+1. Record the repository, branch, exact head SHA, workflow version, and start time.
+2. Confirm the worktree or CI checkout corresponds to the recorded SHA.
+3. Generate source checksums using the canonical repository script.
+4. Validate the ArchISO profile and all safety assertions.
+5. Run the canonical ISO build command with `pipefail` enabled and preserve complete output.
+6. Require a non-empty ISO, `SHA256SUMS`, resolved package lock, and complete build log.
+7. Run `sha256sum -c` against the produced ISO.
+8. Boot that exact ISO under QEMU TCG using the canonical live-boot test.
+9. Require an observed success marker, a zero test exit code, and a machine-readable result.
+10. Scan the QEMU log for panic, oops, emergency-shell, timeout, and explicit failure markers.
+11. Copy the compact evidence files into the versioned evidence directory.
+12. Produce an artifact manifest identifying every retained file by path, size, and SHA-256.
+
+## Canonical commands
+
+Use repository commands rather than reconstructing equivalent ad hoc commands:
+
+```bash
+bash scripts/source-checksums.sh
+bash scripts/validate-iso-profile.sh
+bash scripts/build-iso.sh
+bash scripts/test-qemu-live-boot.sh build/out/*.iso
+sha256sum -c build/out/SHA256SUMS
+```
+
+Stop on the first non-zero command.
+
+## Required output
+
+Report:
+
+- repository and exact head SHA;
+- ISO filename, size, and SHA-256;
+- source checksum file;
+- resolved package lock;
+- build command and exit code;
+- QEMU command and exit code;
+- observed boot marker;
+- workflow run and artifact identifiers when applicable;
+- retained evidence paths;
+- known limitations.
+
+Use one of these dispositions:
+
+- `PASS — ISO build and QEMU live boot verified`
+- `FAIL — build did not produce a valid ISO`
+- `FAIL — checksum verification failed`
+- `FAIL — QEMU live boot was not observed`
+- `INCOMPLETE — required evidence is missing`
+
+## Stop conditions
+
+Stop and preserve evidence when:
+
+- source validation fails;
+- the build writes outside approved output paths;
+- the ISO is absent or empty;
+- checksum verification fails;
+- QEMU exits without the success marker;
+- the test times out;
+- required proof files are missing;
+- a result is only inferred from a previous run.
+
+Classify the blocker as code, dependency, network, permissions, configuration, environment, evidence, or missing information.
+
+## Truth boundary
+
+A pass proves only that the recorded commit produced the recorded ISO and that the ISO reached the live-boot marker in the recorded QEMU test. It does not prove disk installation, installed reboot, Btrfs correctness, systemd service completeness, DREAMER operation, physical-hardware compatibility, or production readiness.

--- a/skills/arklinux-pr-evidence-review/SKILL.md
+++ b/skills/arklinux-pr-evidence-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: arklinux-pr-evidence-review
+description: Review an ARKlinux pull request, current head commit, CI runs, workflow artifacts, logs, and permanent evidence against a narrowly stated milestone. Use when asked whether a PR is complete, ready for review, safe to merge, contaminated, overstated, or missing proof.
+compatibility: Requires read access to the GitHub repository, pull request metadata and diff, Actions runs and artifacts, and any referenced evidence files. Write actions require separate explicit authorization.
+metadata:
+  author: 1TRUE-INC
+  version: "1.0.0"
+---
+
+# ARKlinux pull-request evidence review
+
+## Purpose
+
+Determine exactly what the current pull request proves. Separate implemented code, successful execution evidence, unsupported claims, and explicit non-scope. Produce a concrete disposition and the smallest next instruction.
+
+## Required inputs
+
+Resolve:
+
+- repository;
+- pull-request number;
+- current head SHA;
+- stated milestone and acceptance criteria;
+- required artifacts and evidence files;
+- whether the user requested read-only review, a review submission, readiness transition, or merge.
+
+Never treat an earlier head SHA or earlier successful run as proof for the current head.
+
+## Review workflow
+
+1. Fetch current PR metadata and confirm open/closed, draft status, base, head branch, head SHA, mergeability, and scope statement.
+2. Inspect all changed filenames and the relevant patches, not only the PR description.
+3. Identify destructive operations, permissions changes, external dependencies, mocks, placeholders, success-shaped stubs, and scope expansion.
+4. Fetch CI runs associated with the exact current head SHA.
+5. Confirm required workflows completed and distinguish success, skipped, neutral, cancelled, timed out, and failure states.
+6. Fetch the run artifacts and verify names, sizes, expiration, and required contents.
+7. Inspect machine-readable summaries and logs when required by the milestone.
+8. Compare every acceptance criterion with direct evidence.
+9. Confirm permanent compact evidence exists in Git history when required.
+10. Confirm the PR description's limitations match the actual remaining gaps.
+11. Identify unresolved review threads, failed checks, missing files, stale evidence, or contradictions.
+12. Produce a bounded disposition and exact corrective actions.
+
+## Evidence classifications
+
+Classify each material claim as:
+
+- `VERIFIED`: directly supported for the current head by inspected evidence;
+- `SUPPORTED`: strongly supported, but one independent check is unavailable;
+- `NOT VERIFIED`: plausible, but evidence is absent or incomplete;
+- `CONTRADICTED`: inspected evidence conflicts with the claim;
+- `OUT OF SCOPE`: deliberately not attempted in this milestone;
+- `STALE`: evidence applies to an earlier commit or run.
+
+Do not collapse these categories into a general statement that a PR “looks good.”
+
+## Readiness gate
+
+A PR may be recommended as ready for review only when:
+
+- the current head has the required passing checks;
+- every required artifact exists;
+- evidence retention and permanent records satisfy the milestone;
+- the claim is no broader than the proof;
+- no destructive or security-critical ambiguity remains within scope;
+- explicit non-scope is preserved.
+
+Readiness is not approval, and approval is not merge authorization.
+
+## Required output
+
+Provide:
+
+1. Current PR state and exact head SHA.
+2. Current CI run IDs and conclusions.
+3. Acceptance-criteria table with evidence classification.
+4. Scope-drift and safety findings.
+5. Missing or stale evidence.
+6. One disposition:
+   - `READY FOR REVIEW`
+   - `REMAIN DRAFT`
+   - `REQUEST CHANGES`
+   - `BLOCKED — MISSING ACCESS`
+   - `BLOCKED — TECHNICAL FAILURE`
+7. Exact next instructions suitable for the coding agent.
+
+## Write-action rule
+
+Do not mark ready, approve, request changes, merge, close, retarget, label, or comment unless the user explicitly asks for that specific GitHub mutation. A general request to “review” authorizes read-only inspection only.
+
+## Truth boundary
+
+A merged PR proves that changes entered the base branch. It does not independently prove installation, runtime correctness, hardware compatibility, production readiness, legal compliance, or the truth of historical evidence files. Validate the specific claim against the current commit and direct execution evidence.

--- a/skills/arklinux-qemu-install-proof/SKILL.md
+++ b/skills/arklinux-qemu-install-proof/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: arklinux-qemu-install-proof
+description: Install ARKlinux only onto an explicitly created disposable QEMU disk, then boot from the installed disk without the ISO and verify UEFI, systemd-boot, Btrfs, fstab, and base system state. Use for Milestone 2 installation and installed-reboot proof.
+compatibility: Requires a verified ARKlinux ISO, QEMU x86_64, OVMF, qemu-img, bash, jq or Python 3, and an isolated environment with no physical block-device passthrough.
+metadata:
+  author: 1TRUE-INC
+  version: "1.0.0"
+---
+
+# ARKlinux disposable QEMU installation proof
+
+## Purpose
+
+Prove that a verified ARKlinux ISO can install to a fresh virtual disk and that the installed system can reboot under UEFI without the ISO. This skill must never target a physical disk.
+
+## Required inputs
+
+Resolve:
+
+- exact ISO path and verified SHA-256;
+- repository and exact commit;
+- virtual-disk format and size;
+- generated unique test serial;
+- canonical Btrfs layout;
+- expected installed boot marker;
+- evidence output directory;
+- timeout values.
+
+## Absolute safety rules
+
+- Create the virtual disk inside the approved build or test directory.
+- Do not pass through host block devices, USB storage, NVMe devices, LVM volumes, or raw `/dev/*` paths.
+- The installer must receive an explicit target path, expected serial, disposable-disk assertion, and typed destructive confirmation.
+- Reject ambiguous targets and any serial mismatch.
+- The live ISO must not be the installation target.
+- Detach the ISO before the installed-boot test.
+
+A conceptual installer contract is:
+
+```text
+ark-install \
+  --target /dev/vda \
+  --expected-serial ARKTEST-<commit> \
+  --disposable-test-disk \
+  --confirm DESTROY-ARKTEST-<commit>
+```
+
+The repository implementation may differ, but it must enforce equivalent checks.
+
+## Workflow
+
+1. Verify the ISO hash and record its source commit and evidence reference.
+2. Create a new qcow2 or raw virtual disk with a unique generated serial.
+3. Record the virtual-disk path, size, format, hash or creation metadata, and serial.
+4. Start QEMU with OVMF, the ISO as read-only media, and only the disposable virtual disk as writable storage.
+5. Positively identify the target inside the guest by serial and device properties.
+6. Invoke the installer with the explicit safety contract.
+7. Require successful partitioning, formatting, mounting, file copy, initramfs generation, bootloader installation, and clean unmount.
+8. Power off the live environment.
+9. Start a new QEMU process using the installed virtual disk and OVMF state, with the ISO absent.
+10. Require the installed boot marker and an operational systemd target.
+11. Capture and verify:
+    - `lsblk -f`;
+    - `blkid`;
+    - `findmnt`;
+    - `btrfs subvolume list /`;
+    - `/etc/fstab`;
+    - `bootctl status`;
+    - `systemctl is-system-running`;
+    - `systemctl --failed`;
+    - `uname -a`;
+    - `/etc/os-release`;
+    - required ARK base-directory ownership and modes.
+12. Confirm that the observed Btrfs layout matches the one canonical documented layout.
+13. Scan both serial logs for panic, oops, emergency mode, mount failure, bootloader failure, installer target mismatch, and explicit failure markers.
+14. Produce machine-readable installation and installed-reboot summaries.
+
+## Pass conditions
+
+All are required:
+
+- the ISO hash is verified;
+- the created disposable disk is the only writable installation target;
+- target serial and typed confirmation checks pass;
+- installation exits successfully;
+- the ISO is absent during installed reboot;
+- UEFI firmware starts the installed system;
+- systemd-boot reports a valid installed configuration;
+- fstab resolves and required filesystems mount;
+- the exact canonical Btrfs subvolumes exist;
+- the selected operational systemd target is reached;
+- no unexpected base units fail;
+- all required evidence files exist and are non-empty.
+
+## Required output
+
+Report:
+
+- repository and head SHA;
+- ISO filename and SHA-256;
+- QEMU and OVMF versions;
+- virtual-disk path, format, size, and serial;
+- installer command and exit result;
+- installed-boot command and exit result;
+- partition, filesystem, Btrfs, fstab, bootloader, and systemd findings;
+- complete evidence paths and hashes;
+- known limitations.
+
+Use one disposition:
+
+- `PASS — disposable installation and installed reboot verified`
+- `FAIL — target safety validation failed`
+- `FAIL — installation failed`
+- `FAIL — installed disk did not boot without ISO`
+- `FAIL — installed layout or bootloader verification failed`
+- `INCOMPLETE — required evidence is missing`
+
+## Stop conditions
+
+Stop immediately if a host device could be exposed, target identity is uncertain, confirmation does not match, partitioning affects an unexpected device, installation requires the ISO after reboot, or any result is inferred rather than observed.
+
+## Truth boundary
+
+A pass proves disposable QEMU installation and installed reboot for the recorded ISO and configuration. It does not prove full ARK service operation, DREAMER integration, agent execution, evidence persistence across application workflows, networking policy correctness beyond observed checks, or HP Z4 G4 hardware readiness.

--- a/skills/arklinux-release-custody/SKILL.md
+++ b/skills/arklinux-release-custody/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: arklinux-release-custody
+description: Preserve a verified ARKlinux ISO as a durable release asset, verify the uploaded bytes by downloading and rehashing them, record provenance, and establish independent backup custody. Use after a bounded milestone is merged and a physical, permanently accessible copy is required.
+compatibility: Requires access to the merged repository commit, tags and releases, the verified ISO and evidence files, sha256sum, and approved cloud or physical backup destinations. Publishing and deletion require explicit authorization.
+metadata:
+  author: 1TRUE-INC
+  version: "1.0.0"
+---
+
+# ARKlinux release custody
+
+## Purpose
+
+Create a durable binary distribution record without placing a large generated ISO in ordinary Git object history. Preserve the actual ISO, its cryptographic identity, its source and build evidence, and at least one copy outside GitHub.
+
+## Required inputs
+
+Resolve and verify:
+
+- repository and merged commit;
+- version and annotated tag name;
+- ISO path and filename;
+- expected ISO SHA-256;
+- release title and bounded claim;
+- evidence files to attach;
+- approved backup destinations;
+- whether publication is draft or final.
+
+Do not publish from a draft PR head unless the user explicitly authorizes a prerelease and the release is clearly labeled as such.
+
+## Preconditions
+
+1. The source milestone has passed review and has been merged, unless this is explicitly a prerelease.
+2. The local or downloaded ISO matches the expected SHA-256.
+3. The version is not already bound to different bytes.
+4. Release notes accurately state what was and was not verified.
+5. Required compact evidence exists and is internally consistent.
+
+## Workflow
+
+1. Record the repository, merged commit, source PR, CI run, artifact ID, ISO filename, size, and expected hash.
+2. Verify the ISO locally with `sha256sum` before upload.
+3. Create or verify an annotated tag at the intended commit.
+4. Create a draft release first.
+5. Attach the ISO and required evidence files.
+6. Require every asset upload to complete with a non-zero size.
+7. Download the release ISO into a fresh location.
+8. Recalculate its SHA-256 and compare it with the expected value.
+9. Download and inspect the attached checksum and provenance files.
+10. Record the release URL, asset identifier, upload time, downloaded hash, and verifier.
+11. Copy the untouched ISO and evidence package to at least one independent approved storage destination.
+12. Verify the independent copy by hash.
+13. Preserve a physical copy on user-controlled storage when requested.
+14. Publish the release only after all verification passes and the user authorizes publication.
+
+## Required release assets
+
+At minimum:
+
+- versioned ARKlinux ISO;
+- `SHA256SUMS`;
+- `SOURCE_SHA256SUMS`;
+- resolved `packages.lock`;
+- machine-readable test summary;
+- `ARTIFACT_PROVENANCE.json`;
+- `BUILD_RECORD.md`;
+- concise known-limitations record.
+
+## Custody record
+
+The final record must identify:
+
+- repository and release URL;
+- tag and commit SHA;
+- source PR and workflow run;
+- ISO filename, size, and SHA-256;
+- release asset ID or immutable locator when available;
+- upload verification result;
+- independent backup locations without exposing secrets;
+- date each backup was hash-verified;
+- retention or deletion restrictions.
+
+## Stop conditions
+
+Stop before publication when:
+
+- the ISO hash differs;
+- the tag points to the wrong commit;
+- an asset is absent, empty, or silently renamed;
+- release notes overstate the milestone;
+- the version already identifies different bytes;
+- the downloaded release asset cannot be reverified;
+- no independent custody copy exists when one is required.
+
+Never delete the CI artifact, replace a release asset, move a tag, or remove an independent copy without explicit authorization and a replacement verified first.
+
+## Truth boundary
+
+A durable release proves that the preserved bytes correspond to the recorded hash and commit evidence. It does not upgrade the technical claim. An ISO verified only for QEMU live boot remains a live-boot baseline even when permanently released.


### PR DESCRIPTION
## Purpose

Add narrow, reusable Agent Skills for recurring ARKlinux engineering and evidence tasks. This is a stacked draft based on PR #42's branch so it does not expand the ISO milestone itself.

## Included skills

- `arklinux-iso-build-proof`
- `arklinux-pr-evidence-review`
- `arklinux-release-custody`
- `arklinux-qemu-install-proof`

## Supporting controls

- root `AGENTS.md` skill index and authority boundary
- `skills/README.md`
- dependency-free `scripts/validate-agent-skills.py`
- dedicated Agent Skills validation workflow

## Truth boundary

These files standardize how future agents perform and report the tasks. They do not themselves build an ISO, publish a release, install ARKlinux, or prove a milestone.

## Stacked-PR note

Base: `arklinux-iso-qemu-baseline`

After PR #42 is merged, retarget this PR to `main` and confirm only the skill-library changes remain in its diff.
